### PR TITLE
Socket Timeout

### DIFF
--- a/config/default.config
+++ b/config/default.config
@@ -1,5 +1,6 @@
 http {
   server_timeout_time       10000
+  keepalive_timeout			30
   server {
     index                   index.html
     server_name             localhost

--- a/includes/Logger.hpp
+++ b/includes/Logger.hpp
@@ -8,98 +8,118 @@
 #include <ctime>
 
 #define DEBUG(message) { \
-    std::ostringstream oss; \
-    oss << message; \
-    Logger::log(oss.str(), __FILE__, __LINE__, Logger::DEBUG); \
+	std::ostringstream oss; \
+	oss << message; \
+	Logger::log(oss.str(), __FILE__, __LINE__, Logger::DEBUG); \
+}
+#define BLOCK(message) { \
+	std::ostringstream oss; \
+	oss << std::endl << std::endl << message << "*END*" << std::endl << std::endl; \
+	Logger::log(oss.str(), __FILE__, __LINE__, Logger::DEBUG); \
 }
 #define SUCCESS(message) { \
-    std::ostringstream oss; \
-    oss << message; \
-    Logger::log(oss.str(), __FILE__, __LINE__, Logger::SUCCESS); \
+	std::ostringstream oss; \
+	oss << message; \
+	Logger::log(oss.str(), __FILE__, __LINE__, Logger::SUCCESS); \
 }
 #define INFO(message) { \
-    std::ostringstream oss; \
-    oss << message; \
-    Logger::log(oss.str(), __FILE__, __LINE__, Logger::INFO); \
+	std::ostringstream oss; \
+	oss << message; \
+	Logger::log(oss.str(), __FILE__, __LINE__, Logger::INFO); \
 }
 #define WARNING(message) { \
-    std::ostringstream oss; \
-    oss << message; \
-    Logger::log(oss.str(), __FILE__, __LINE__, Logger::WARNING); \
+	std::ostringstream oss; \
+	oss << message; \
+	Logger::log(oss.str(), __FILE__, __LINE__, Logger::WARNING); \
 }
 #define ERROR(message) { \
-    std::ostringstream oss; \
-    oss << message; \
-    Logger::log(oss.str(), __FILE__, __LINE__, Logger::ERROR); \
+	std::ostringstream oss; \
+	oss << message; \
+	Logger::log(oss.str(), __FILE__, __LINE__, Logger::ERROR); \
 }
 
 class Logger {
-    public:
-        enum LogLevel {
+	public:
+		enum LogLevel {
 			DEBUG,
-            SUCCESS,
-            INFO,
-            WARNING,
-            ERROR
-        };
+			SUCCESS,
+			INFO,
+			WARNING,
+			ERROR
+		};
 
-        /**
-         * @brief Initializes the logger. Enables or disables logging and file logging based on parameters.
-         * @param enableLogging Enables overall logging if true.
-         * @param enableLogFile Enables logging to a file instead of the console if true.
-         */
-        static void initialize(bool enableLogging, bool enableLogFile = false);
-        /**
-         * @brief does not print to output or file a specific level from logging.
-         * @param level level of logging to hide. 
-         */
-        static void hide(LogLevel level);
-        /**
-         * @brief Sets whether log messages should include ANSI colour codes or not
-         * @param value If true, log messages will include ANSI colour codes
-         */
-        static void setUseColour(bool value);
+		/**
+		 * @brief Initializes the logger. Enables or disables logging and file logging based on parameters.
+		 * @param enableLogging Enables overall logging if true.
+		 * @param enableLogFile Enables logging to a file instead of the console if true.
+		 */
+		static void initialize(bool enableLogging, bool enableLogFile = false);
+		/**
+		 * @brief does not print to output or file a specific level from logging.
+		 * @param level level of logging to hide. 
+		 */
+		static void hide(LogLevel level);
+		/**
+		 * @brief does not print to output or file a File and Line part of log (Code link at the end).
+		 */
+		static void hideFileLine();
+		/**
+		 * @brief does not print to output or file a Timestamp part of log (time in front of message).
+		 */
+		static void hideTimestamp();
+		/**
+		 * @brief does not print to output or file a Level part of log (INFO/DEBUG/ERROR).
+		 */
+		static void hideLevel();
+		/**
+		 * @brief Sets whether log messages should include ANSI colour codes or not
+		 * @param value If true, log messages will include ANSI colour codes
+		 */
+		static void setUseColour(bool value);
 
-        /**
-         * @brief Logs a message at a specified log level
-         * @param message The message to log.
-         * @param level The log level (default is set to INFO).
-         */
-        static void log(const std::string& message, const char* file, int line, LogLevel level = INFO);
+		/**
+		 * @brief Logs a message at a specified log level
+		 * @param message The message to log.
+		 * @param level The log level (default is set to INFO).
+		 */
+		static void log(const std::string& message, const char* file, int line, LogLevel level = INFO);
 
-        // Deconstructor
-        ~Logger();
-    private:
-        Logger(); // Do not make the class instatiable
-        // Pointer to the output stream (console or file).
-        static std::ostream* output;
-        static std::ofstream fileStream;
-        static bool debugEnabled;
-        static bool successEnabled;
-        static bool infoEnabled;
-        static bool warningEnabled;
-        static bool errorEnabled;
-        static bool useColour;
+		// Deconstructor
+		~Logger();
+	private:
+		Logger(); // Do not make the class instatiable
+		// Pointer to the output stream (console or file).
+		static std::ostream* output;
+		static std::ofstream fileStream;
+		static bool debugEnabled;
+		static bool successEnabled;
+		static bool infoEnabled;
+		static bool warningEnabled;
+		static bool errorEnabled;
+		static bool useColour;
+		static bool useFileLine;
+		static bool useTimestamp;
+		static bool useLevel;
 
-        /**
-         * @brief A string representation of the log level
-         * @param level The level to convert to string.
-         * @return String representation of the log level
-         */
-        static std::string getLevelString(LogLevel level);
+		/**
+		 * @brief A string representation of the log level
+		 * @param level The level to convert to string.
+		 * @return String representation of the log level
+		 */
+		static std::string getLevelString(LogLevel level);
 
-        /**
-         * @brief Returns the ANSI color code for the given log level
-         * @param level The log level to get the colour code for.
-         * @return ANSI color code as a string
-         */
-        static std::string getColor(LogLevel level);
-        
-        /**
-         * @brief Sets the file to which log messages will be written to
-         * @param filename The name of the file to use for logging
-         */
-        static void setLogFile(const std::string& filename);
+		/**
+		 * @brief Returns the ANSI color code for the given log level
+		 * @param level The log level to get the colour code for.
+		 * @return ANSI color code as a string
+		 */
+		static std::string getColor(LogLevel level);
+		
+		/**
+		 * @brief Sets the file to which log messages will be written to
+		 * @param filename The name of the file to use for logging
+		 */
+		static void setLogFile(const std::string& filename);
 };
 
 #endif

--- a/includes/SocketManager.hpp
+++ b/includes/SocketManager.hpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <fstream>
 #include <streambuf>
+#include <ctime>
 
 #include "Structs.hpp"
 #include "HTTPRequest.hpp"
@@ -28,7 +29,6 @@ class SocketManager {
 		void acceptNewConnections(int server_fd);
 		void closeConnection(int fd);
 		int createAndBindSocket(int port);
-		void handleClientRequest(pollfd &fd);
 		void addServerFd(int fd);
 		bool isServerSocket(int fd);
 		ServerConfig& getCurrentServer(const HTTPRequest& request);

--- a/includes/Structs.hpp
+++ b/includes/Structs.hpp
@@ -6,46 +6,43 @@
 #include <string>
 
 enum RequestTypes {
-    GET,
-    DELETE,
-    POST,
+	GET,
+	DELETE,
+	POST,
 };
 
 enum SectionTypes {
-    HTTP,
-    SERVER,
-    LOCATION,
-    UNKNOWN,
+	HTTP,
+	SERVER,
+	LOCATION,
+	UNKNOWN,
 };
 
 struct ClientState {
-    std::string readBuffer;
-    std::string writeBuffer;
-    bool requestComplete;
-    bool responseComplete;
-
-    // Default constructor
-    ClientState() : requestComplete(false), responseComplete(false) {}
+	std::string readBuffer;
+	std::string writeBuffer;
+	bool keepAlive;
+	time_t lastActivity;
 };
 
 struct LocationConfig {
-    std::vector<RequestTypes> allowedRequestTypes;
-    std::string locationPath;
+	std::vector<RequestTypes> allowedRequestTypes;
+	std::string locationPath;
 };
 
 struct ServerConfig {
-    std::string indexFile;
-    std::string serverName;
-    int clientMaxBodySize;
-    int listenPort;
-    std::string rootDirectory;
-    bool directoryListing;
-    std::vector<LocationConfig> locations;
+	std::string indexFile;
+	std::string serverName;
+	int clientMaxBodySize;
+	int listenPort;
+	std::string rootDirectory;
+	bool directoryListing;
+	std::vector<LocationConfig> locations;
 };
 
 struct HTTPConfig {
-    std::vector<ServerConfig> serverConfigs;
-    int server_timeout_time;
+	std::vector<ServerConfig> serverConfigs;
+	int server_timeout_time;
 };
 
 #endif

--- a/includes/Structs.hpp
+++ b/includes/Structs.hpp
@@ -23,6 +23,8 @@ struct ClientState {
 	std::string writeBuffer;
 	bool keepAlive;
 	time_t lastActivity;
+	bool closeConnection;
+	ClientState() : closeConnection(false){};
 };
 
 struct LocationConfig {
@@ -43,6 +45,7 @@ struct ServerConfig {
 struct HTTPConfig {
 	std::vector<ServerConfig> serverConfigs;
 	int server_timeout_time;
+	int keepAliveTimeout;
 };
 
 #endif

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -35,7 +35,6 @@ void HTTPRequest::parseRequest(const std::string& request) {
 		requestStream.read(&body[0], length);
 	}
 	SUCCESS("Recived HTTP Request: " << method << " on " << uri);
-	BLOCK(request);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -35,6 +35,7 @@ void HTTPRequest::parseRequest(const std::string& request) {
 		requestStream.read(&body[0], length);
 	}
 	SUCCESS("Recived HTTP Request: " << method << " on " << uri);
+	BLOCK(request);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/HTTPResponse.cpp
+++ b/src/HTTPResponse.cpp
@@ -88,7 +88,8 @@ void HTTPResponse::assignPageNotFoundContent(const ServerConfig& serverConfig) {
 void HTTPResponse::assignResponse(int statusCode, const std::string& body, std::string contentType) {
 	setHeader("Content-Type", contentType);
 	setHeader("Content-Length", ::toString(body.size() - 1));
-	setHeader("Connection", "keep-alive"); // TODO depending on client request
+	setHeader("Connection", "keep-alive");
+	setHeader("Keep-Alive", "timeout=60");
 	setBody(body);
 	setStatusCode(statusCode);
 }

--- a/src/HTTPResponse.cpp
+++ b/src/HTTPResponse.cpp
@@ -89,7 +89,7 @@ void HTTPResponse::assignResponse(int statusCode, const std::string& body, std::
 	setHeader("Content-Type", contentType);
 	setHeader("Content-Length", ::toString(body.size() - 1));
 	setHeader("Connection", "keep-alive");
-	setHeader("Keep-Alive", "timeout=60");
+	setHeader("Keep-Alive", "timeout=60, max=50");
 	setBody(body);
 	setStatusCode(statusCode);
 }

--- a/src/SocketManager.cpp
+++ b/src/SocketManager.cpp
@@ -103,7 +103,7 @@ int SocketManager::createAndBindSocket(int port) {
 		return -1;
 	}
 
-	if (fcntl(sockfd, F_SETFL, O_NONBLOCK) < 0) {
+	if (fcntl(sockfd, F_SETFL, O_NONBLOCK | FD_CLOEXEC) < 0) {
 		closeConnection(sockfd);
 		ERROR("Failed to set to non blocking mode for socket: *" << sockfd << "*");
 		return -1;
@@ -143,7 +143,7 @@ void SocketManager::acceptNewConnections(int server_fd) {
 
 	this->clientStates[newsockfd] = ClientState();
 
-	fcntl(newsockfd, F_SETFL, O_NONBLOCK);
+	fcntl(newsockfd, F_SETFL, O_NONBLOCK | FD_CLOEXEC);
 
 	struct pollfd new_pfd = {newsockfd, POLLIN, 0};
 	this->fds.push_back(new_pfd);

--- a/src/SocketManager.cpp
+++ b/src/SocketManager.cpp
@@ -56,23 +56,34 @@ void SocketManager::run() {
 		for (size_t i = 0; i < this->fds.size(); i++) {
 			if (this->fds[i].revents & POLLIN) {
 				INFO("Recived a request on a socket *" << this->fds[i].fd << "*");
+				time(&clientStates[fds[i].fd].lastActivity);
 				if (isServerSocket(this->fds[i].fd)) {
 					acceptNewConnections(this->fds[i].fd);
 				} else {
-					handleClientRequest(fds[i]);
+					fds[i].events |= POLLOUT;
+					if (readClientData(fds[i].fd))
+						processRequest(fds[i].fd);
 				}
 			}
 			if (this->fds[i].revents & POLLOUT && !isServerSocket(this->fds[i].fd)) {
 				INFO("Sending response back to client from socket *" << this->fds[i].fd << "*");
+				time(&clientStates[fds[i].fd].lastActivity);
 				sendResponse(fds[i]);
 			}
 			if (this->fds[i].revents & (POLLERR | POLLHUP | POLLNVAL)) {
 				if (this->fds[i].revents & (POLLERR))
-					ERROR("POLLERR : operation on the file descriptor failed unexpectedly on socket *" << fds[i].fd << "*");
+					WARNING("POLLERR : operation on the file descriptor failed unexpectedly on socket *" << fds[i].fd << "*");
 				if (this->fds[i].revents & (POLLHUP))
-					ERROR("POLLHUP : client closed the connection on socket *" << fds[i].fd << "*");
+					WARNING("POLLHUP : client closed the connection on socket *" << fds[i].fd << "*");
 				if (this->fds[i].revents & (POLLNVAL))
-					ERROR("POLLNVAL : file descriptor is not open or invalid on socket *" << fds[i].fd << "*");
+					WARNING("POLLNVAL : file descriptor is not open or invalid on socket *" << fds[i].fd << "*");
+				closeConnection(this->fds[i].fd);
+				i--;
+			}
+			time_t now;
+			time(&now);
+			if (difftime(now, clientStates[fds[i].fd].lastActivity) > 10 && !isServerSocket(this->fds[i].fd)){
+				WARNING("TIMEOUT on socket *" << fds[i].fd << "*");
 				closeConnection(this->fds[i].fd);
 				i--;
 			}
@@ -147,34 +158,21 @@ void SocketManager::acceptNewConnections(int server_fd) {
 
 	struct pollfd new_pfd = {newsockfd, POLLIN, 0};
 	this->fds.push_back(new_pfd);
+	time(&clientStates[newsockfd].lastActivity);
 	SUCCESS("Server socket *" << server_fd << "* Accepted new connection on socket *" << newsockfd << "*");
-}
-
-void SocketManager::handleClientRequest(pollfd &fd) {
-	fd.events |= POLLOUT;
-	if (!clientStates[fd.fd].requestComplete) {
-		if (readClientData(fd.fd) && clientStates[fd.fd].requestComplete) {
-			processRequest(fd.fd);
-		}
-	}
 }
 
 /* ----------------------------- Handle Requests ---------------------------- */
 
 bool SocketManager::readClientData(int fd) {
-	INFO("Reading client request:");
 	char buffer[4096 * 10];
 	ssize_t bytesRead = recv(fd, buffer, sizeof(buffer), 0);
 	if (bytesRead > 0) {
 		this->clientStates[fd].readBuffer.append(buffer, bytesRead);
 		if (this->clientStates[fd].readBuffer.find("\r\n\r\n") != std::string::npos) {
-			this->clientStates[fd].requestComplete = true;
 			return true;
 		}
-	} else if (bytesRead == 0) {
-		WARNING("Client connection is closed");
-		closeConnection(fd);
-	} else {
+	} else if (bytesRead < 0) {
 		ERROR("Failed to read from recv()");
 		closeConnection(fd);
 	}
@@ -190,7 +188,6 @@ void SocketManager::processRequest(int fd) {
 	try {
 		HTTPResponse response;
 		response.prepareResponse(request, serverConfig);
-		clientStates[fd].responseComplete = false;
 		clientStates[fd].writeBuffer = response.convertToString();
 	} catch (const std::runtime_error& e) {
 		ERROR(e.what());
@@ -203,6 +200,7 @@ void SocketManager::sendResponse(pollfd &fd) {
 		fd.events = POLLIN;
 		return;
 	}
+	BLOCK(clientStates[fd.fd].writeBuffer);
 	ssize_t bytesWritten = send(fd.fd, clientStates[fd.fd].writeBuffer.c_str(), clientStates[fd.fd].writeBuffer.size(), 0);
 	if (bytesWritten > 0) {
 		clientStates[fd.fd].writeBuffer.erase(0, bytesWritten);

--- a/src/config-manager/ConfigManager.cpp
+++ b/src/config-manager/ConfigManager.cpp
@@ -68,6 +68,8 @@ void ConfigManager::parseHttpSection(std::ifstream& configFile, std::string& lin
             if (value.empty())
                 throw std::runtime_error("Value is missing for 'server_timeout_time'");
             this->httpConfig.server_timeout_time = convertStringToInt(value);
+		} else if (key == "keepalive_timeout") {
+        	this->httpConfig.keepAliveTimeout = convertStringToInt(value);
         } else if (line == "server {") {
             ServerConfig serverConfig;
             initServerConfig(serverConfig);

--- a/src/config-manager/ConfigManager.cpp
+++ b/src/config-manager/ConfigManager.cpp
@@ -30,7 +30,7 @@ void ConfigManager::parseConfigFile(std::string configFilePath) {
     }
     configFile.close();
     validateConfiguration();
-    SUCCESS("Parsing was successful");
+    SUCCESS("Parsing Config was successful");
 }
 
 void ConfigManager::initServerConfig(ServerConfig& serverConfig) {


### PR DESCRIPTION
## 1. Added `FD_CLOEXEC` flag to `fcntl()` calls
### Benefits of Setting FD_CLOEXEC:

- Security: By setting FD_CLOEXEC, you prevent child processes (such as those running CGI scripts) from inheriting file descriptors. This is crucial in maintaining security because it ensures that sensitive file descriptors are not accessible to unauthorized or less secure processes.

- Resource Management: Automatically closing file descriptors in child processes helps manage system resources more efficiently, preventing leaks that could eventually lead to resource exhaustion.

- Simplicity in Process Management: When child processes do not inherit unnecessary file descriptors, managing these processes becomes simpler. There's less need for explicit cleanup, reducing the risk of bugs related to improper handling of open file descriptors.

## 2. Log Improvement
- Added 3 functions for hiding different elements of log
<img width="276" alt="image" src="https://github.com/RealConrad/42webserv/assets/131430279/b552fad3-8eb1-4af6-8656-27fea5a427f0">

- output :
<img width="291" alt="image" src="https://github.com/RealConrad/42webserv/assets/131430279/b85ec9b4-d6d5-4580-855d-0033f2aaeea2">

- added BLOCK() macro that uses DEBUG for printing big chunks of data like HTTP responses/requests
<img width="165" alt="image" src="https://github.com/RealConrad/42webserv/assets/131430279/bf5087e6-b9a9-417d-b311-9c3c607d0d0c">

- output :
<img width="636" alt="image" src="https://github.com/RealConrad/42webserv/assets/131430279/0110cfa7-0d6c-4869-9b99-c631dd044749">


## 3. ClientState update
- removed `bool requestComplete` & `bool responseComplete`
because we dont need them
- added keepAlive bit and lastActivity for implementing Timestamp

## 4. Socket Timeout
- Added timeout in config (default 75)
<img width="285" alt="image" src="https://github.com/RealConrad/42webserv/assets/131430279/bc55b042-0849-4b73-bb2a-749221b3c295">

- Timeout on a single request
 <img width="662" alt="image" src="https://github.com/RealConrad/42webserv/assets/131430279/e207e17e-488c-432f-97c1-c8cc37ae0b37">

- Timeout after several requests
<img width="568" alt="image" src="https://github.com/RealConrad/42webserv/assets/131430279/aab3a5e0-3ac2-4df2-847c-d323e3dfcbee">

- Connection termination when without "keep-alive"
<img width="554" alt="image" src="https://github.com/RealConrad/42webserv/assets/131430279/813dc5b0-004f-47cf-a857-3b07f637ef4b">



## 5. Closing socket in one place
I added a socket bool that terminates sockets in one place: 
<img width="540" alt="image" src="https://github.com/RealConrad/42webserv/assets/131430279/4d789e02-2d13-4874-9e4c-2e759aff7e7b">

It is because of i-- and clean approach. Only other close sockets are in the server setup. 

